### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,27 +1,27 @@
 #######################################
 # Classes
 #######################################
-FifteenStep		KEYWORD1
-FifteenStepNote		KEYWORD1
+FifteenStep	KEYWORD1
+FifteenStepNote	KEYWORD1
 
 #######################################
 # Functions
 #######################################
-begin			KEYWORD2
-run			KEYWORD2
-start			KEYWORD2
-stop			KEYWORD2
-pause			KEYWORD2
-panic			KEYWORD2
-setNote			KEYWORD2
-setTempo		KEYWORD2
-setSteps		KEYWORD2
-increaseTempo		KEYWORD2
-decreaseTempo		KEYWORD2
-increaseShuffle		KEYWORD2
-decreaseShuffle		KEYWORD2
-setMidiHandler		KEYWORD2
-setStepHandler		KEYWORD2
+begin	KEYWORD2
+run	KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
+pause	KEYWORD2
+panic	KEYWORD2
+setNote	KEYWORD2
+setTempo	KEYWORD2
+setSteps	KEYWORD2
+increaseTempo	KEYWORD2
+decreaseTempo	KEYWORD2
+increaseShuffle	KEYWORD2
+decreaseShuffle	KEYWORD2
+setMidiHandler	KEYWORD2
+setStepHandler	KEYWORD2
 
 #######################################
 # Constants
@@ -30,6 +30,6 @@ setStepHandler		KEYWORD2
 FS_DEFAULT_TEMPO	LITERAL1
 FS_DEFAULT_STEPS	LITERAL1
 FS_DEFAULT_MEMORY	LITERAL1
-FS_MIN_TEMPO		LITERAL1
-FS_MAX_TEMPO		LITERAL1
-FS_MAX_STEPS		LITERAL1
+FS_MIN_TEMPO	LITERAL1
+FS_MAX_TEMPO	LITERAL1
+FS_MAX_STEPS	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords