### PR TITLE
Better clock

### DIFF
--- a/FifteenStep.cpp
+++ b/FifteenStep.cpp
@@ -162,13 +162,15 @@ void FifteenStep::setTempo(int tempo)
   if(_tempo > FS_MAX_TEMPO)
     _tempo = FS_MAX_TEMPO;
 
-  // 60 seconds / bpm / 4 sixteeth notes per beat
-  // gives you the value of a sixteenth note
-  _sixteenth = 60000L / _tempo / 4;
-
   // midi clock messages should be sent 24 times
   // for every quarter note
   _clock = 60000L / _tempo / 24;
+
+  // 60 seconds / bpm / 4 sixteeth notes per beat
+  // gives you the value of a sixteenth note
+  // but we calculate it as 6 * _clock to minimize
+  // rounding errors
+  _sixteenth = 6 * _clock;
 
   // grab new shuffle division
   unsigned long div = _shuffleDivision();

--- a/FifteenStep.cpp
+++ b/FifteenStep.cpp
@@ -117,24 +117,25 @@ void FifteenStep::run()
   unsigned long now = millis();
   // it's time to get ill.
 
+  // only step if it's time
+  if(now >= _next_beat) {
+    // resync clock to beat
+    _next_clock = _next_beat;
+    // advance and send notes
+    _step();
+
+    // add shuffle offset to next beat if needed
+    if((_position % 2) == 0)
+        _next_beat = now + _sixteenth + _shuffle;
+    else
+        _next_beat = now + _sixteenth - _shuffle;
+  }
+
   // send clock
   if(now >= _next_clock) {
     _tick();
     _next_clock = now + _clock;
   }
-
-  // only step if it's time
-  if(now < _next_beat)
-    return;
-
-  // advance and send notes
-  _step();
-
-  // add shuffle offset to next beat if needed
-  if((_position % 2) == 0)
-    _next_beat = now + _sixteenth + _shuffle;
-  else
-    _next_beat = now + _sixteenth - _shuffle;
 
 }
 


### PR DESCRIPTION
This adds two improvements to reduce time drift between `_next_beat` and `_next_clock`. Because those are currently two independent timers, a MidiClock synced device will drift off from the internal steps of the sequencer over time.

The PR contains two changes, and with these I could finally run the metronome of a clock synced synthesizer, with no audible drift against a metronome generated from the FifteenStep sequencer:

### Minimize rounding errors

The calculations for `_clock` and `_sixteenth` can introduce quite some rounding errors for term values that don't evenly divide by 24, e.g.:

    tempo = 120
    _sixteenth = 83
    _clock = 20

By deriving `_sixteenth` from `_clock`, we can minimize the drift between steps and ticks.

### Resync _next_clock on every _step
Because `_next_clock` changes 6 times more often than `_next_beat`, it will accumulate drift independently of `_next_beat`. 
(Every call to`run()` comes some amount of `millis()` later than the scheduled timer -
this difference lets timing slowly drift behind the intended clock/beat ticks).

By `tick()`ing only after checking `_next_beat`, we can resync the two timers on every (sixteenth) beat.

