### PR TITLE
byte doesn't allow for negative

### DIFF
--- a/FifteenStep.cpp
+++ b/FifteenStep.cpp
@@ -347,13 +347,13 @@ void FifteenStep::setStepHandler(StepCallback cb)
 // position, the note will be turned off.
 //
 // @access public
-// @param note on or off message
+// @param channel
 // @param pitch of note
 // @param velocity of note
 // @param position in sequence
 // @return void
 //
-void FifteenStep::setNote(byte channel, byte pitch, byte velocity, byte step)
+void FifteenStep::setNote(byte channel, byte pitch, byte velocity, int step)
 {
 
   // don't save notes if the sequencer isn't running

--- a/FifteenStep.h
+++ b/FifteenStep.h
@@ -85,7 +85,7 @@ class FifteenStep
     void  decreaseShuffle();
     void  setMidiHandler(MIDIcallback cb);
     void  setStepHandler(StepCallback cb);
-    void  setNote(byte channel, byte pitch, byte velocity, byte step = -1);
+    void  setNote(byte channel, byte pitch, byte velocity, int step = -1);
     byte  getPosition();
     FifteenStepNote* getSequence();
   private:


### PR DESCRIPTION
The definition of `addNote` has a (byte typed) `step` param (with a default value of -1); therefore the following code (lines 369-372):

```
if(step == -1)
    position = _quantizedPosition();
  else
    position = step;
```

_should_ result in `position` being equal to `_quantizedPosition()` when you omit the `step` from the addNote call.

However a `byte` doesn't allow for a negative value (and -1 gets _silently_ casted to 255: see https://www.arduino.cc/reference/en/language/variables/data-types/byte/). Therefore when omitting the step (or setting it to -1) the _actual_ value will be `255` and consequently the `position` will also result in `255`... and not what we expect.

Typing the `step` param as `byte` solves this.